### PR TITLE
allow disapproval and gen metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install ligo dependencies
         run: /root/ligo install
       - name: Build
-        run: LIGO=/root/ligo make build
+        run: LIGO=/root/ligo BUILD_VERSION=${{ needs.set_env_vars.outputs.release_version }} make build
       - name: Test
         run: LIGO=/root/ligo make test
       - name: Package
@@ -51,6 +51,16 @@ jobs:
           tag_name: ${{ needs.set_env_vars.outputs.release_version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload metadata
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./_build/app/metadata.json
+          asset_name: metadata.json
+          asset_content_type: application/json
       - name: Upload unit contract
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-release-asset@v1

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LIGO_CURRENT_VERSION:=$(shell $(LIGO) --version)
 LIGO_INSTALL=$(LIGO) install
 
 # Tezos binaries
-TEZOS_BINARIES_VERSION:=v14.1-1
+TEZOS_BINARIES_VERSION:=v15.1-1
 TEZOS_BINARIES_REPO:=https://github.com/serokell/tezos-packaging/releases/download/
 TEZOS_BINARIES_URL:=$(TEZOS_BINARIES_REPO)$(TEZOS_BINARIES_VERSION)
 
@@ -66,15 +66,15 @@ ifneq (${LIGO_VERSION},${LIGO_CURRENT_VERSION})
 endif
 
 gen-wallet:
-	$(BUILD_DIRECTORY)/tezos-client gen keys wallet_address -f 2> /dev/null
-	$(BUILD_DIRECTORY)/tezos-client show address wallet_address -S 2> /dev/null
+	$(BUILD_DIRECTORY)/octez-client gen keys wallet_address -f 2> /dev/null
+	$(BUILD_DIRECTORY)/octez-client show address wallet_address -S 2> /dev/null
 	@echo -e "\e[32m!!! Please go https://faucet.marigold.dev/ to request some XTZ !!!\e[0m"
 
 deploy:
 	$(eval SIGNER := $(shell TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes ./_build/tezos-client --endpoint https://ghostnet.tezos.marigold.dev show address wallet_address | grep Hash | awk '{print $$2}'))
-	$(BUILD_DIRECTORY)/tezos-client --endpoint https://ghostnet.tezos.marigold.dev originate contract $(PROJECT_NAME)_unit transferring 2 from wallet_address running $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_unit.tez --init '(Pair 0 {} {"$(SIGNER)";} 1 {})' --burn-cap 1 -f
-	$(BUILD_DIRECTORY)/tezos-client --endpoint https://ghostnet.tezos.marigold.dev originate contract $(PROJECT_NAME)_bytes transferring 2 from wallet_address running $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_bytes.tez --init '(Pair 0 {} {"$(SIGNER)";} 1 {})' --burn-cap 1 -f
+	$(BUILD_DIRECTORY)/octez-client --endpoint https://ghostnet.tezos.marigold.dev originate contract $(PROJECT_NAME)_unit transferring 2 from wallet_address running $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_unit.tez --init '(Pair 0 {} {"$(SIGNER)";} 1 {})' --burn-cap 1 -f
+	$(BUILD_DIRECTORY)/octez-client --endpoint https://ghostnet.tezos.marigold.dev originate contract $(PROJECT_NAME)_bytes transferring 2 from wallet_address running $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_bytes.tez --init '(Pair 0 {} {"$(SIGNER)";} 1 {})' --burn-cap 1 -f
 
 get-tezos-binary:
-	wget -O $(BUILD_DIRECTORY)/tezos-client $(TEZOS_BINARIES_URL)/tezos-client
-	chmod +x $(BUILD_DIRECTORY)/tezos-client
+	wget -O $(BUILD_DIRECTORY)/octez-client $(TEZOS_BINARIES_URL)/octez-client
+	chmod +x $(BUILD_DIRECTORY)/octez-client

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 .PHONY: build test ligo-version
 .PHONY: clean tarball-app
 .PHONY: install get-tezos-binary gen_wallet deploy
+.PHONY: build-contract build-metadata
 
 # Environment variables
 
 # The version for artifacts releases
 PROJECT_NAME:=$(shell basename $(CURDIR))
-BUILD_VERISON := $(shell git describe --always)
+BUILD_VERSION ?= $(shell git describe --always)
 
 # The path of directory
 BUILD_DIRECTORY:=_build
@@ -34,8 +35,12 @@ all: build test tarball-app
 install:
 	ligo install
 
-# TODO: adding check-ligo-version when ligo release new version for bug fix
-build:
+build: build-contract build-metadata
+
+build-metadata:
+	VERSION=$(BUILD_VERSION) bash ./script/gen_metadata.sh > $(BUILT_APP_DIRECTORY)/metadata.json
+
+build-contract: check-ligo-version
 	mkdir -p $(BUILT_APP_DIRECTORY)
 	$(LIGO_BUILD) $(APP_DIRECTORY)/main_unit.mligo > $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_unit.tez
 	$(LIGO_BUILD) $(APP_DIRECTORY)/main_bytes.mligo > $(BUILT_APP_DIRECTORY)/$(PROJECT_NAME)_bytes.tez
@@ -50,7 +55,7 @@ clean:
 	rm -rf esy.lock
 
 tarball-app:
-	tar czvf $(BUILD_DIRECTORY)/$(PROJECT_NAME)-$(BUILD_VERISON).tar.gz $(BUILT_APP_DIRECTORY)/*.tez
+	tar czvf $(BUILD_DIRECTORY)/$(PROJECT_NAME)-$(BUILD_VERSION).tar.gz $(BUILT_APP_DIRECTORY)/*
 
 ligo-version:
 	@echo $(LIGO_VERSION)

--- a/README.md
+++ b/README.md
@@ -97,11 +97,27 @@ Each signer can create proposal through this entrypoint. The entrypoint supports
   - tag: `create_proposal`
   - data: `(proposal id, created proposal)`
 
-### sign_proposal
-Signers can provide an approval through this entrypoint. The signer who is statisfied the minimal requestment of approvals will also trigger the execution of proposal. After the proposal has been executed, signers can not provide their approvals.
+### sign_and_execute_proposal
+Signers can provide an approval or a disapproval through this entrypoint. The signer who is statisfied the minimal requestment of approvals will also trigger the execution of proposal. After the proposal has been executed, signers can not provide their approvals.
 
 - Emit event
   - tag: `sign_proposal`
+  - data: `(proposal id, signer)`
+  - tag: `execute_proposal` (only when proposal is executed)
+  - data: `(proposal id, signer)`
+
+# sign_proposal_only
+Signers can provide an approval or a disapproval through this entrypoint. Unlike `sign_and_execute_proposal`, the proposal won't be execute in any case.
+
+- Emit event
+  - tag: `sign_proposal`
+  - data: `(proposal id, signer)`
+
+# execute_proposal
+Signers can execute proposal when minimal requestment is statisfied.
+
+- Emit event
+  - tag: `execute_proposal`
   - data: `(proposal id, signer)`
 
 # Deploy
@@ -116,4 +132,3 @@ We provide several steps for quick deploying contracts in `app/` to ghostnet.
 # TODO
 - support a different kind of threshold
 - support FA2.1
-- split execution from sign entrypoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-signature",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Marigold <contact@marigold.dev>",
   "description": "Multi-signature wallet",
   "scripts": {

--- a/script/gen_metadata.sh
+++ b/script/gen_metadata.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo '
+{
+    "name": "multisig",
+    "description": "Marigold Multisig Contract",
+    "version": "'${VERSION}'",
+    "license": {
+        "name": "MIT"
+    },
+    "authors": [
+        "Marigold <contract@marigold.dev>"
+    ],
+    "homepage": "https://marigold.dev",
+    "source": {
+        "tools": "cameligo",
+        "location": "https://github.com/marigold-dev/multisig/"
+    },
+    "interfaces": [
+        "TZIP-016"
+    ]
+}'

--- a/src/internal/conditions.mligo
+++ b/src/internal/conditions.mligo
@@ -37,7 +37,7 @@ let amount_must_be_zero_tez (an_amout : tez) : unit =
 
 [@inline]
 let not_sign_yet (type a) (proposal : a storage_types_proposal) : unit =
-    assert_with_error (not Set.mem (Tezos.get_sender ()) proposal.approved_signers) Errors.has_already_signed
+    assert_with_error (not Map.mem (Tezos.get_sender ()) proposal.signatures) Errors.has_already_signed
 
 [@inline]
 let ready_to_execute (executed : address option) : unit =

--- a/src/internal/contract.mligo
+++ b/src/internal/contract.mligo
@@ -57,14 +57,14 @@ let create_proposal (type a) (proposal_content, storage : (a proposal_content) l
  * Proposal signature
  *)
 
-let sign_proposal (type a) (proposal_id, agreement, storage : Parameter.Types.proposal_id * Parameter.Types.agreement * a storage_types) : a result =
+let sign_and_execute_proposal (type a) (proposal_id, agreement, storage : Parameter.Types.proposal_id * Parameter.Types.agreement * a storage_types) : a result =
     let () = Conditions.only_signer storage in
     let proposal = Storage.Op.retrieve_proposal(proposal_id, storage) in
     let () = Conditions.not_execute_yet proposal.executed in
     let () = Conditions.not_sign_yet proposal in
     let signer = Tezos.get_sender () in
     let proposal = Storage.Op.update_signature (proposal, signer, agreement) in
-    let proposal = Storage.Op.update_execution_flag (proposal, storage.threshold) in
+    let proposal = Storage.Op.update_proposal_state (proposal, Set.cardinal storage.signers,storage.threshold) in
     let storage = Storage.Op.update_proposal(proposal_id, proposal, storage) in
     let ops, storage = Execution.perform_operations proposal storage in
     let ops = Tezos.emit "%sign_proposal" (proposal_id, signer)::ops in
@@ -96,7 +96,7 @@ let execute_proposal (type a) (proposal_id, storage : Parameter.Types.proposal_i
     let proposal = Storage.Op.retrieve_proposal(proposal_id, storage) in
     let () = Conditions.not_execute_yet proposal.executed in
     let signer = Tezos.get_sender () in
-    let proposal = Storage.Op.update_execution_flag (proposal, storage.threshold) in
+    let proposal = Storage.Op.update_proposal_state (proposal, Set.cardinal storage.signers, storage.threshold) in
     let () = Conditions.ready_to_execute proposal.executed in
     let storage = Storage.Op.update_proposal(proposal_id, proposal, storage) in
     let ops, s = Execution.perform_operations proposal storage in
@@ -110,7 +110,7 @@ let contract (type a) (action, storage : a request) : a result =
     | Create_proposal proposal_params ->
         create_proposal (proposal_params, storage)
     | Sign_and_execute_proposal (proposal_id, agreement) ->
-        sign_proposal (proposal_id, agreement, storage)
+        sign_and_execute_proposal (proposal_id, agreement, storage)
     | Sign_proposal_only (proposal_id, agreement) ->
         sign_proposal_only (proposal_id, agreement, storage)
     | Execute_proposal proposal_id ->

--- a/src/internal/execution.mligo
+++ b/src/internal/execution.mligo
@@ -25,6 +25,7 @@
 
 type storage_types = Storage.Types.t
 type storage_types_proposal = Storage.Types.proposal
+type storage_types_proposal_state = Storage.Types.proposal_state
 type proposal_content = Proposal_content.Types.t
 
 let send_by (type a) (parameter: a) (target : address) (amount : tez) : operation =
@@ -49,6 +50,6 @@ let perform_operations (type a) (proposal: a storage_types_proposal) (storage : 
       | Some op -> op::ops, new_s
       | None -> ops, new_s
     in
-    if Util.is_some proposal.executed
+    if proposal.state = (Done : storage_types_proposal_state)
     then List.fold_left batch (Constants.no_operation, storage) proposal.content
     else (Constants.no_operation, storage)

--- a/src/internal/parameter.mligo
+++ b/src/internal/parameter.mligo
@@ -21,11 +21,12 @@
 module Types = struct
     type proposal_content = Proposal_content.Types.t
     type proposal_id = nat
+    type agreement = bool
 
     type 'a t =
     | Default of unit
     | Create_proposal of ('a proposal_content) list
-    | Sign_and_execute_proposal of proposal_id
-    | Sign_proposal_only of proposal_id
+    | Sign_and_execute_proposal of (proposal_id * agreement)
+    | Sign_proposal_only of (proposal_id * agreement)
     | Execute_proposal of proposal_id
 end

--- a/src/internal/storage.mligo
+++ b/src/internal/storage.mligo
@@ -64,6 +64,7 @@ end
 module Op = struct
     type proposal_content = Proposal_content.Types.t
     type proposal_id = Parameter.Types.proposal_id
+    type agreement = Parameter.Types.agreement
     type proposal = Types.proposal
     type types = Types.t
 
@@ -97,10 +98,10 @@ module Op = struct
 
 
     [@inline]
-    let add_approval (type a) (proposal, signer: a proposal * address) : a proposal =
+    let update_signature (type a) (proposal, signer, agreement: a proposal * address * agreement) : a proposal =
         {
             proposal with
-            signatures = Map.add signer true proposal.signatures;
+            signatures = Map.update signer (Some agreement) proposal.signatures;
         }
 
     [@inline]

--- a/src/views_lib.mligo
+++ b/src/views_lib.mligo
@@ -37,10 +37,10 @@ let to_view_proposal_content (type a) (p : a proposal_content) : (a view_proposa
 
 let to_view_proposal (type a) (p : a proposal) : (a view_proposal) =
   {
-    approved_signers = p.approved_signers;
+    state            = p.state;
+    signatures       = p.signatures;
     proposer         = p.proposer;
     executed         = p.executed;
-    number_of_signer = p.number_of_signer;
     timestamp        = p.timestamp;
     content          = List.map to_view_proposal_content p.content;
   }

--- a/test/common/helper.mligo
+++ b/test/common/helper.mligo
@@ -43,11 +43,11 @@ let originate (type a) (level: Breath.Logger.level) (main : a request -> a resul
 let create_proposal (type a) (contract : (a parameter_types, a storage_types) originated) (proposal : (a proposal_content) list) () =
   Breath.Contract.transfert_with_entrypoint_to contract "create_proposal" proposal 0tez
 
-let sign_and_execute_proposal (type a) (contract : (a parameter_types, a storage_types) originated) (proposal_number : nat) () =
-  Breath.Contract.transfert_with_entrypoint_to contract "sign_and_execute_proposal" proposal_number 0tez
+let sign_and_execute_proposal (type a) (contract : (a parameter_types, a storage_types) originated) (proposal_number : nat) (agreement : bool) () =
+  Breath.Contract.transfert_with_entrypoint_to contract "sign_and_execute_proposal" (proposal_number, agreement) 0tez
 
-let sign_proposal_only (type a) (contract : (a parameter_types, a storage_types) originated) (proposal_number : nat) () =
-  Breath.Contract.transfert_with_entrypoint_to contract "sign_proposal_only" proposal_number 0tez
+let sign_proposal_only (type a) (contract : (a parameter_types, a storage_types) originated) (proposal_number : nat) (agreement : bool) () =
+  Breath.Contract.transfert_with_entrypoint_to contract "sign_proposal_only" (proposal_number, agreement) 0tez
 
 let execute_proposal (type a) (contract : (a parameter_types, a storage_types) originated) (proposal_number : nat) () =
   Breath.Contract.transfert_with_entrypoint_to contract "execute_proposal" proposal_number 0tez

--- a/test/test.mligo
+++ b/test/test.mligo
@@ -29,6 +29,7 @@
 #import "./test_view.mligo" "View"
 #import "./test_sign_only_entrypoint.mligo" "Sign_ony"
 #import "./test_execute_proposal_entrypoint.mligo" "Exe"
+#import "./test_disapproval.mligo" "Disapproval"
 
 let () =
   Breath.Model.run_suites Void
@@ -43,4 +44,5 @@ let () =
   ; View.test_suite
   ; Sign_ony.test_suite
   ; Exe.test_suite
+  ; Disapproval.test_suite
   ]

--- a/test/test_adjust_threshold_proposal.mligo
+++ b/test/test_adjust_threshold_proposal.mligo
@@ -40,7 +40,7 @@ let case_execute_adjust_threshold_proposal =
       (* create proposal *)
       let param = Adjust_threshold 2n :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
 

--- a/test/test_basic_proposal.mligo
+++ b/test/test_basic_proposal.mligo
@@ -74,10 +74,10 @@ let case_create_proposal =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 4n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.empty;
+          state            = Active;
+          signatures       = Map.empty;
           proposer         = alice.address;
           executed         = None;
-          number_of_signer = 0n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             parameter        = 10n;
@@ -87,10 +87,10 @@ let case_create_proposal =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.empty;
+          state            = Active;
+          signatures       = Map.empty;
           proposer         = bob.address;
           executed         = None;
-          number_of_signer = 0n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             target           = add_contract.originated_address;
@@ -100,10 +100,10 @@ let case_create_proposal =
         })
       ; Assert.is_proposal_equal "#3 proposal" proposal3
         ({
-          approved_signers = Set.empty;
+          state            = Active;
+          signatures       = Map.empty;
           proposer         = bob.address;
           executed         = None;
-          number_of_signer = 0n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             parameter        = ();
@@ -113,10 +113,10 @@ let case_create_proposal =
         })
       ; Assert.is_proposal_equal "#4 proposal" proposal4
         ({
-          approved_signers = Set.empty;
+          state            = Active;
+          signatures       = Map.empty;
           proposer         = bob.address;
           executed         = None;
-          number_of_signer = 0n;
           timestamp        = Tezos.get_now ();
           content          =
             [ Transfer {parameter = (); amount = 10tez; target = alice.address; }

--- a/test/test_change_signer_proposal.mligo
+++ b/test/test_change_signer_proposal.mligo
@@ -40,7 +40,7 @@ let case_execute_add_signer_proposal =
       (* create proposal *)
       let param = Add_signers (Set.literal [bob.address; carol.address]) :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
 
@@ -66,7 +66,7 @@ let case_execute_add_existed_signer_proposal =
       (* create proposal *)
       let param = Add_signers (Set.literal [alice.address;]) :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
 
@@ -92,7 +92,7 @@ let case_execute_remove_signer_proposal =
       (* create proposal *)
       let param = Remove_signers (Set.literal [bob.address; carol.address]) :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
 
@@ -118,7 +118,7 @@ let case_execute_remove_nonexisted_signer_proposal =
       (* create proposal *)
       let param = Remove_signers (Set.literal [bob.address; carol.address]) :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
 

--- a/test/test_disapproval.mligo
+++ b/test/test_disapproval.mligo
@@ -1,0 +1,278 @@
+(* MIT License
+   Copyright (c) 2022 Marigold <contact@marigold.dev>
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal in
+   the Software without restriction, including without limitation the rights to
+   use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+   the Software, and to permit persons to whom the Software is furnished to do so,
+   subject to the following conditions:
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+#import "ligo-breathalyzer/lib/lib.mligo" "Breath"
+#import "./common/helper.mligo" "Helper"
+#import "./common/assert.mligo" "Assert"
+#import "./common/mock_contract.mligo" "Mock_contract"
+#import "./common/util.mligo" "Util"
+#import "../src/internal/proposal_content.mligo" "Proposal_content"
+
+type proposal_content = Proposal_content.Types.t
+
+let case_sign_for_disapproval =
+  Breath.Model.case
+  "test sign proposal with disproposal"
+  "successufully sign proposal"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (alice, bob, carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [alice.address; bob.address; carol.address] in
+      let init_storage = Helper.init_storage (signers, 1n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 100tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
+      let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n false) in
+
+      let balance = Breath.Contract.balance_of multisig_contract in
+      let storage = Breath.Contract.storage_of multisig_contract in
+
+      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposal_map) "proposal 1 doesn't exist" in
+
+      Breath.Result.reduce [
+        create_action1
+      ; sign_action1
+      ; Breath.Assert.is_equal "balance" balance 100tez
+      ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
+      ; Assert.is_proposal_equal "#1 proposal" proposal1
+        ({
+          state            = Active;
+          signatures       = Map.literal [(bob.address, false)];
+          proposer         = alice.address;
+          executed         = None;
+          timestamp        = Tezos.get_now ();
+          content          = [ Execute {
+            amount           = 0tez;
+            target           = add_contract.originated_address;
+            parameter        = 10n;
+          }]
+        })
+      ])
+
+let case_fail_double_sign =
+  Breath.Model.case
+  "sign the same proposal twice"
+  "fail to sign"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (alice, bob, _carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [alice.address; bob.address;] in
+      let init_storage = Helper.init_storage (signers, 2n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 0tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
+      let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
+      let sign_action2 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n false) in
+
+      Breath.Result.reduce [
+        action1
+      ; sign_action1
+      ; Breath.Expect.fail_with_message "You have already signed this proposal" sign_action2
+      ])
+
+let case_close_proposal_1_1 =
+  Breath.Model.case
+  "test close proposal with threshold 1 of 1"
+  "successufully close proposal"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (_alice, bob, _carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [bob.address;] in
+      let init_storage = Helper.init_storage (signers, 1n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 100tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 10tez;} :: param) in
+      let create_action1 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n false) in
+
+      let balance = Breath.Contract.balance_of multisig_contract in
+      let storage = Breath.Contract.storage_of multisig_contract in
+
+      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposal_map) "proposal 1 doesn't exist" in
+
+      let add_contract_balance = Breath.Contract.balance_of add_contract in
+
+      Breath.Result.reduce [
+        create_action1
+      ; sign_action1
+      ; Breath.Assert.is_equal "balance" balance 100tez
+      ; Breath.Assert.is_equal "balance of add contract" add_contract_balance 0tez
+      ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
+      ; Assert.is_proposal_equal "#1 proposal" proposal1
+        ({
+          state            = Closed;
+          signatures       = Map.literal [(bob.address, false)];
+          proposer         = bob.address;
+          executed         = Some bob.address;
+          timestamp        = Tezos.get_now ();
+          content          = [ Execute {
+            amount           = 10tez;
+            target           = add_contract.originated_address;
+            parameter        = 10n;
+          }]
+        })
+      ])
+
+let case_close_proposal_2_2 =
+  Breath.Model.case
+  "test close proposal with threshold 2 of 2"
+  "successufully close proposal"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (alice, bob, _carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [alice.address; bob.address;] in
+      let init_storage = Helper.init_storage (signers, 2n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 100tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 10tez;} :: param) in
+      let create_action1 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n false) in
+
+      let balance = Breath.Contract.balance_of multisig_contract in
+      let storage = Breath.Contract.storage_of multisig_contract in
+
+      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposal_map) "proposal 1 doesn't exist" in
+
+      let add_contract_balance = Breath.Contract.balance_of add_contract in
+
+      Breath.Result.reduce [
+        create_action1
+      ; sign_action1
+      ; Breath.Assert.is_equal "balance" balance 100tez
+      ; Breath.Assert.is_equal "balance of add contract" add_contract_balance 0tez
+      ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
+      ; Assert.is_proposal_equal "#1 proposal" proposal1
+        ({
+          state            = Closed;
+          signatures       = Map.literal [(alice.address, false)];
+          proposer         = bob.address;
+          executed         = Some alice.address;
+          timestamp        = Tezos.get_now ();
+          content          = [ Execute {
+            amount           = 10tez;
+            target           = add_contract.originated_address;
+            parameter        = 10n;
+          }]
+        })
+      ])
+
+let case_close_proposal_2_3 =
+  Breath.Model.case
+  "test close proposal with threshold 2 of 3"
+  "successufully close proposal"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (alice, bob, carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [alice.address; bob.address; carol.address] in
+      let init_storage = Helper.init_storage (signers, 2n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 100tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 10tez;} :: param) in
+      let create_action1 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n false) in
+      let sign_action2 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n false) in
+
+      let balance = Breath.Contract.balance_of multisig_contract in
+      let storage = Breath.Contract.storage_of multisig_contract in
+
+      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposal_map) "proposal 1 doesn't exist" in
+
+      let add_contract_balance = Breath.Contract.balance_of add_contract in
+
+      Breath.Result.reduce [
+        create_action1
+      ; sign_action1
+      ; sign_action2
+      ; Breath.Assert.is_equal "balance" balance 100tez
+      ; Breath.Assert.is_equal "balance of add contract" add_contract_balance 0tez
+      ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
+      ; Assert.is_proposal_equal "#1 proposal" proposal1
+        ({
+          state            = Closed;
+          signatures       = Map.literal [(bob.address, false); (alice.address, false)];
+          proposer         = bob.address;
+          executed         = Some bob.address;
+          timestamp        = Tezos.get_now ();
+          content          = [ Execute {
+            amount           = 10tez;
+            target           = add_contract.originated_address;
+            parameter        = 10n;
+          }]
+        })
+      ])
+
+let case_not_closed_1_2 =
+  Breath.Model.case
+  "test not close proposal with threshold 1 of 2"
+  "not close proposal"
+    (fun (level: Breath.Logger.level) ->
+      let (_, (alice, bob, carol)) = Breath.Context.init_default () in
+      let signers : address set = Set.literal [alice.address; bob.address; carol.address] in
+      let init_storage = Helper.init_storage (signers, 2n) in
+      let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 100tez in
+      let add_contract = Breath.Contract.originate level "add_contr" Mock_contract.add_main 1n 0tez in
+      let param = ([] : (nat proposal_content) list) in
+
+      let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 10tez;} :: param) in
+      let create_action1 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param1) in
+      let sign_action1 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n false) in
+
+      let balance = Breath.Contract.balance_of multisig_contract in
+      let storage = Breath.Contract.storage_of multisig_contract in
+
+      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposal_map) "proposal 1 doesn't exist" in
+
+      let add_contract_balance = Breath.Contract.balance_of add_contract in
+
+      Breath.Result.reduce [
+        create_action1
+      ; sign_action1
+      ; Breath.Assert.is_equal "balance" balance 100tez
+      ; Breath.Assert.is_equal "balance of add contract" add_contract_balance 0tez
+      ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
+      ; Assert.is_proposal_equal "#1 proposal" proposal1
+        ({
+          state            = Active;
+          signatures       = Map.literal [(alice.address, false)];
+          proposer         = bob.address;
+          executed         = None;
+          timestamp        = Tezos.get_now ();
+          content          = [ Execute {
+            amount           = 10tez;
+            target           = add_contract.originated_address;
+            parameter        = 10n;
+          }]
+        })
+      ])
+
+let test_suite =
+  Breath.Model.suite "Suite for allowing disproposal" [
+    case_sign_for_disapproval
+  ; case_fail_double_sign
+  ; case_close_proposal_1_1
+  ; case_close_proposal_2_2
+  ; case_close_proposal_2_3
+  ; case_not_closed_1_2
+  ]

--- a/test/test_emit_events.mligo
+++ b/test/test_emit_events.mligo
@@ -71,7 +71,7 @@ let case_emitted_sign_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let multisig_address = multisig_contract.originated_address in
 
       let events = (Util.get_last_events_from multisig_address "sign_proposal" : (storage_types_proposal_id * address) list) in
@@ -99,7 +99,7 @@ let case_emitted_exe_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let exe_action1 = Breath.Context.act_as bob (Helper.execute_proposal multisig_contract 1n) in
 
       let multisig_address = multisig_contract.originated_address in
@@ -129,7 +129,7 @@ let case_emitted_sign_and_execute_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
       let multisig_address = multisig_contract.originated_address in
 
       let sign_events = (Util.get_last_events_from multisig_address "sign_proposal" : (storage_types_proposal_id * address) list) in
@@ -161,7 +161,7 @@ let case_emitted_sign_proposal_without_exe_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
       let multisig_address = multisig_contract.originated_address in
 
       let sign_events = (Util.get_last_events_from multisig_address "sign_proposal" : (storage_types_proposal_id * address) list) in

--- a/test/test_execute_proposal_entrypoint.mligo
+++ b/test/test_execute_proposal_entrypoint.mligo
@@ -66,7 +66,7 @@ let case_execute_proposal =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
@@ -79,7 +79,7 @@ let case_execute_proposal =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(carol.address, true)];
           proposer         = bob.address;
           executed         = Some alice.address;

--- a/test/test_execute_proposal_entrypoint.mligo
+++ b/test/test_execute_proposal_entrypoint.mligo
@@ -40,13 +40,13 @@ let case_execute_proposal =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let exe_action1 = Breath.Context.act_as bob (Helper.execute_proposal multisig_contract 1n) in
 
       (* create proposal 2 *)
       let param2 = (Transfer { target = bob.address; parameter = (); amount = 20tez;} :: param) in
       let create_action2 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param2) in
-      let sign_action2 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n) in
+      let sign_action2 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n true) in
       let exe_action2 = Breath.Context.act_as alice (Helper.execute_proposal multisig_contract 2n) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
@@ -107,7 +107,7 @@ let case_fail_to_execute_proposal_twice =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let exe_action1 = Breath.Context.act_as bob (Helper.execute_proposal multisig_contract 1n) in
       let exe_action2 = Breath.Context.act_as bob (Helper.execute_proposal multisig_contract 1n) in
 
@@ -132,7 +132,7 @@ let case_not_signer =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let exe_action1 = Breath.Context.act_as carol (Helper.execute_proposal multisig_contract 1n) in
 
       Breath.Result.reduce [
@@ -155,7 +155,7 @@ let case_no_enough_signature =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
       let exe_action1 = Breath.Context.act_as bob (Helper.execute_proposal multisig_contract 1n) in
 
       Breath.Result.reduce [
@@ -171,5 +171,3 @@ let test_suite =
   ; case_not_signer
   ; case_no_enough_signature
   ]
-
-

--- a/test/test_execute_proposal_entrypoint.mligo
+++ b/test/test_execute_proposal_entrypoint.mligo
@@ -66,10 +66,10 @@ let case_execute_proposal =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [bob.address];
+          state            = Active;
+          signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             amount           = 0tez;
@@ -79,10 +79,10 @@ let case_execute_proposal =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.literal [carol.address];
+          state            = Active;
+          signatures       = Map.literal [(carol.address, true)];
           proposer         = bob.address;
           executed         = Some alice.address;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             parameter        = ();

--- a/test/test_lambda_proposal.mligo
+++ b/test/test_lambda_proposal.mligo
@@ -48,7 +48,7 @@ let case_execute_lambda_proposal =
       (* create proposal *)
       let param = Execute_lambda (call_add_contract) :: param in
       let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let add_contract_storage = Breath.Contract.storage_of add_contract in
 

--- a/test/test_sign_and_execute_entrypoint.mligo
+++ b/test/test_sign_and_execute_entrypoint.mligo
@@ -40,12 +40,12 @@ let case_gathering_signatures =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       (* create proposal 2 *)
       let param2 = (Transfer { target = bob.address; parameter = (); amount = 20tez;} :: param) in
       let create_action2 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param2) in
-      let sign_action2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n) in
+      let sign_action2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n true) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
@@ -103,12 +103,12 @@ let case_execute_transaction_1_of_1 =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       (* create proposal 2 *)
       let param2 = (Transfer { target = bob.address; parameter = (); amount = 20tez;} :: param) in
       let create_action2 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param2) in
-      let sign_action2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n) in
+      let sign_action2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n true) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
@@ -168,7 +168,7 @@ let case_execute_transaction_1_of_1_batch =
         ; Transfer { target = bob.address; parameter = (); amount = 20tez;}
         ] in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
@@ -215,16 +215,16 @@ let case_execute_transaction_3_of_3 =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1_1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
-      let sign_action1_2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 1n) in
-      let sign_action1_3 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1_1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
+      let sign_action1_2 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 1n true) in
+      let sign_action1_3 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       (* create proposal 2 *)
       let param2 = (Transfer { target = bob.address; parameter = (); amount = 20tez;} :: param) in
       let create_action2 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param2) in
-      let sign_action2_1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n) in
-      let sign_action2_2 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 2n) in
-      let sign_action2_3 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 2n) in
+      let sign_action2_1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n true) in
+      let sign_action2_2 = Breath.Context.act_as alice (Helper.sign_and_execute_proposal multisig_contract 2n true) in
+      let sign_action2_3 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 2n true) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
@@ -285,8 +285,8 @@ let case_fail_double_sign =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
-      let sign_action2 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
+      let sign_action2 = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       Breath.Result.reduce [
         action1
@@ -308,7 +308,7 @@ let case_unauthorized_user_fail_to_sign =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 1n true) in
 
       Breath.Result.reduce [
         action1
@@ -329,7 +329,7 @@ let case_sign_nonexisted_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n) in
+      let sign_action1 = Breath.Context.act_as carol (Helper.sign_and_execute_proposal multisig_contract 2n true) in
 
       Breath.Result.reduce [
         action1

--- a/test/test_sign_and_execute_entrypoint.mligo
+++ b/test/test_sign_and_execute_entrypoint.mligo
@@ -125,7 +125,7 @@ let case_execute_transaction_1_of_1 =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
@@ -138,7 +138,7 @@ let case_execute_transaction_1_of_1 =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(carol.address, true)];
           proposer         = bob.address;
           executed         = Some carol.address;
@@ -182,7 +182,7 @@ let case_execute_transaction_1_of_1_batch =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
@@ -245,7 +245,7 @@ let case_execute_transaction_3_of_3 =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(alice.address, true); (bob.address, true); (carol.address, true)];
           proposer         = alice.address;
           executed         = Some alice.address;
@@ -258,7 +258,7 @@ let case_execute_transaction_3_of_3 =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          state            = Active;
+          state            = Done;
           signatures       = Map.literal [(alice.address, true); (bob.address, true); (carol.address, true)];
           proposer         = bob.address;
           executed         = Some bob.address;

--- a/test/test_sign_and_execute_entrypoint.mligo
+++ b/test/test_sign_and_execute_entrypoint.mligo
@@ -62,10 +62,10 @@ let case_gathering_signatures =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [bob.address];
+          state            = Active;
+          signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = None;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             amount           = 0tez;
@@ -75,10 +75,10 @@ let case_gathering_signatures =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.literal [carol.address];
+          state            = Active;
+          signatures       = Map.literal [(carol.address, true)];
           proposer         = bob.address;
           executed         = None;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             parameter        = ();
@@ -125,10 +125,10 @@ let case_execute_transaction_1_of_1 =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [bob.address;];
+          state            = Active;
+          signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             target           = add_contract.originated_address;
@@ -138,10 +138,10 @@ let case_execute_transaction_1_of_1 =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.literal [carol.address;];
+          state            = Active;
+          signatures       = Map.literal [(carol.address, true)];
           proposer         = bob.address;
           executed         = Some carol.address;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             target           = bob.address;
@@ -182,10 +182,10 @@ let case_execute_transaction_1_of_1_batch =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 1n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [bob.address;];
+          state            = Active;
+          signatures       = Map.literal [(bob.address, true)];
           proposer         = alice.address;
           executed         = Some bob.address;
-          number_of_signer = 1n;
           timestamp        = Tezos.get_now ();
           content          =
             [ Execute {
@@ -245,10 +245,10 @@ let case_execute_transaction_3_of_3 =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [alice.address; bob.address; carol.address];
+          state            = Active;
+          signatures       = Map.literal [(alice.address, true); (bob.address, true); (carol.address, true)];
           proposer         = alice.address;
           executed         = Some alice.address;
-          number_of_signer = 3n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             target           = add_contract.originated_address;
@@ -258,10 +258,10 @@ let case_execute_transaction_3_of_3 =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.literal [alice.address; bob.address; carol.address];
+          state            = Active;
+          signatures       = Map.literal [(alice.address, true); (bob.address, true); (carol.address, true)];
           proposer         = bob.address;
           executed         = Some bob.address;
-          number_of_signer = 3n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             target           = bob.address;

--- a/test/test_sign_only_entrypoint.mligo
+++ b/test/test_sign_only_entrypoint.mligo
@@ -66,10 +66,10 @@ let case_gathering_signatures =
       ; Breath.Assert.is_equal "the counter of proposal" storage.proposal_counter 2n
       ; Assert.is_proposal_equal "#1 proposal" proposal1
         ({
-          approved_signers = Set.literal [bob.address; carol.address];
+          state            = Active;
+          signatures       = Map.literal [(bob.address, true); (carol.address, true)];
           proposer         = alice.address;
           executed         = None;
-          number_of_signer = 2n;
           timestamp        = Tezos.get_now ();
           content          = [ Execute {
             amount           = 0tez;
@@ -79,10 +79,10 @@ let case_gathering_signatures =
         })
       ; Assert.is_proposal_equal "#2 proposal" proposal2
         ({
-          approved_signers = Set.literal [carol.address; alice.address];
+          state            = Active;
+          signatures       = Map.literal [(carol.address, true); (alice.address, true)];
           proposer         = bob.address;
           executed         = None;
-          number_of_signer = 2n;
           timestamp        = Tezos.get_now ();
           content          = [ Transfer {
             parameter        = ();

--- a/test/test_sign_only_entrypoint.mligo
+++ b/test/test_sign_only_entrypoint.mligo
@@ -40,14 +40,14 @@ let case_gathering_signatures =
       (* create proposal 1 *)
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1_1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
-      let sign_action1_2 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1_1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
+      let sign_action1_2 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n true) in
 
       (* create proposal 2 *)
       let param2 = (Transfer { target = bob.address; parameter = (); amount = 20tez;} :: param) in
       let create_action2 = Breath.Context.act_as bob (Helper.create_proposal multisig_contract param2) in
-      let sign_action2_1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n) in
-      let sign_action2_2 = Breath.Context.act_as alice (Helper.sign_proposal_only multisig_contract 2n) in
+      let sign_action2_1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n true) in
+      let sign_action2_2 = Breath.Context.act_as alice (Helper.sign_proposal_only multisig_contract 2n true) in
 
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
@@ -106,8 +106,8 @@ let case_fail_double_sign =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
-      let sign_action2 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
+      let sign_action2 = Breath.Context.act_as bob (Helper.sign_proposal_only multisig_contract 1n true) in
 
       Breath.Result.reduce [
         action1
@@ -129,7 +129,7 @@ let case_unauthorized_user_fail_to_sign =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_action1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n true) in
 
       Breath.Result.reduce [
         action1
@@ -150,7 +150,7 @@ let case_sign_nonexisted_proposal =
 
       let param1 = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let action1 = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param1) in
-      let sign_action1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n) in
+      let sign_action1 = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 2n true) in
 
       Breath.Result.reduce [
         action1
@@ -190,8 +190,8 @@ let case_fail_to_sign_after_executed_flag_set =
 
       let param = (Execute { target = add_contract.originated_address; parameter = 10n; amount = 0tez;} :: param) in
       let create_action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
-      let sign_exe_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n) in
-      let sign_action = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n) in
+      let sign_exe_action = Breath.Context.act_as bob (Helper.sign_and_execute_proposal multisig_contract 1n true) in
+      let sign_action = Breath.Context.act_as carol (Helper.sign_proposal_only multisig_contract 1n true) in
 
       Breath.Result.reduce [
         create_action


### PR DESCRIPTION
There two major changes:

- allow disapproval
  - add a state to proposal 
  - user can sign disapproval through entrypoint `sign_proposal_only` or `sign_and_execute_contract`
  - if the proposal has minimal disapproval, proposal can be closed through entrypoint of `exexute_proposal` or `sign_and_execute_contract`
- gen `metadata.json`
  - `metadata.json` can be used for metadata field in storage while contract originate.
  - `metadata.json` will be upload to release note.
- bump version to `0.0.6`