### PR TITLE
[Feature] implement tzip26, proof of event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - 0.1.0
+      - release-0.3
   pull_request:
     branches:
-      - 0.1.0
+      - release-0.3
 
 jobs:
   set_env_vars:

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ TEST_DIRECTORY:=test
 BUILT_APP_DIRECTORY:=$(BUILD_DIRECTORY)/$(APP_DIRECTORY)
 
 # Ligo compiler
-LIGO_COMPILER_ARGS:=--protocol kathmandu
-LIGO_VERSION:=0.60.0
+LIGO_COMPILER_ARGS:=--protocol nairobi
+LIGO_VERSION:=0.70.1
 LIGO?=ligo
 LIGO_BUILD=$(LIGO) compile contract $(LIGO_COMPILER_ARGS)
 LIGO_TEST=$(LIGO) run test
@@ -25,7 +25,7 @@ LIGO_CURRENT_VERSION:=$(shell $(LIGO) --version)
 LIGO_INSTALL=$(LIGO) install
 
 # Tezos binaries
-TEZOS_BINARIES_VERSION:=v15.1-1
+TEZOS_BINARIES_VERSION:=v17.1-1
 TEZOS_BINARIES_REPO:=https://github.com/serokell/tezos-packaging/releases/download/
 TEZOS_BINARIES_URL:=$(TEZOS_BINARIES_REPO)$(TEZOS_BINARIES_VERSION)
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "TzSafe",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "author": "Marigold <contact@marigold.dev>",
-  "description": "TzSafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet",
+  "description": "TzSafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet. The implementation adheres to the guidelines specified in TZIP-26.",
   "scripts": {
     "test": "ligo run test test/test.mligo --project-root ."
   },

--- a/src/internal/conditions.mligo
+++ b/src/internal/conditions.mligo
@@ -80,8 +80,7 @@ let check_setting (type a) (storage : a storage_types) : unit =
     ()
 
 [@inline]
-let check_proposals_content (type a) (from_input: (a proposal_content) list) (from_storage: (a proposal_content) list) : unit =
-  let pack_from_input = Bytes.pack from_input in
+let check_proposals_content (type a) (pack_from_input : bytes) (from_storage: (a proposal_content) list) : unit =
   let pack_from_storage = Bytes.pack from_storage in
   assert_with_error (pack_from_input = pack_from_storage) Errors.not_the_same_content
 

--- a/src/internal/parameter.mligo
+++ b/src/internal/parameter.mligo
@@ -20,13 +20,14 @@
 
 module Types = struct
     type proposal_content = Proposal_content.Types.t
-    type proposal_id = nat
+    type proposal_id = bytes
     type agreement = bool
     type expiration_time = timestamp
+    type proof_of_event_challenge = { challenge_id : bytes; payload : bytes; }
 
     type 'a t =
     | Default of unit
     | Create_proposal of ('a proposal_content) list
     | Sign_proposal of (proposal_id * ('a proposal_content) list * agreement)
-    | Resolve_proposal of proposal_id * ('a proposal_content) list
+    | Proof_of_event_challenge of proof_of_event_challenge
 end

--- a/src/internal/storage.mligo
+++ b/src/internal/storage.mligo
@@ -85,7 +85,7 @@ module Op = struct
     [@inline]
     let register_proposal (type a) (proposal, storage: a proposal * a types) : a types =
         let proposal_counter = storage.proposal_counter + 1n in
-        let proposals = Big_map.add proposal_counter proposal storage.proposals in
+        let proposals = Big_map.add (bytes proposal_counter) proposal storage.proposals in
         {
             storage with
             proposals     = proposals;

--- a/test/test_basic_proposal.mligo
+++ b/test/test_basic_proposal.mligo
@@ -60,10 +60,10 @@ let case_create_proposal =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
-      let proposal2 = Util.unopt (Big_map.find_opt 2n storage.proposals) "proposal 2 doesn't exist" in
-      let proposal3 = Util.unopt (Big_map.find_opt 3n storage.proposals) "proposal 3 doesn't exist" in
-      let proposal4 = Util.unopt (Big_map.find_opt 4n storage.proposals) "proposal 4 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
+      let proposal2 = Util.unopt (Big_map.find_opt 0x02 storage.proposals) "proposal 2 doesn't exist" in
+      let proposal3 = Util.unopt (Big_map.find_opt 0x03 storage.proposals) "proposal 3 doesn't exist" in
+      let proposal4 = Util.unopt (Big_map.find_opt 0x04 storage.proposals) "proposal 4 doesn't exist" in
 
       Breath.Result.reduce [
         action1
@@ -133,7 +133,7 @@ let case_fail_to_create_empty_proposal =
       let multisig_contract = Helper.originate level Mock_contract.multisig_main init_storage 0tez in
       let param = ([] : (nat proposal_content) list) in
 
-      let action = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
+      let action : Breath.Result.result = Breath.Context.act_as alice (Helper.create_proposal multisig_contract param) in
 
       Breath.Result.reduce [
         Breath.Expect.fail_with_message "There is no content in proposal" action

--- a/test/test_change_owner_proposal.mligo
+++ b/test/test_change_owner_proposal.mligo
@@ -45,7 +45,7 @@ let case_execute_add_owner_proposal =
 
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         action
@@ -180,7 +180,7 @@ let case_resolve_transfer_proposal_after_owner_changed =
 
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         action1

--- a/test/test_disapproval.mligo
+++ b/test/test_disapproval.mligo
@@ -44,7 +44,7 @@ let case_sign_for_disapproval =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -108,7 +108,7 @@ let case_close_proposal_1_1 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       let add_contract_balance = Breath.Contract.balance_of add_contract in
 
@@ -153,7 +153,7 @@ let case_close_proposal_2_2 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       let add_contract_balance = Breath.Contract.balance_of add_contract in
 
@@ -199,7 +199,7 @@ let case_close_proposal_2_3 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       let add_contract_balance = Breath.Contract.balance_of add_contract in
 
@@ -245,7 +245,7 @@ let case_not_closed_1_2 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       let add_contract_balance = Breath.Contract.balance_of add_contract in
 

--- a/test/test_emit_events.mligo
+++ b/test/test_emit_events.mligo
@@ -49,11 +49,11 @@ let case_emitted_create_proposal =
       let (emitted_id, emitted_proposal) = Option.unopt (List.head_opt events) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
-      let proposal = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         action1
-      ; Breath.Assert.is_equal "proposal id" emitted_id 1n
+      ; Breath.Assert.is_equal "proposal id" emitted_id 0x01
       ; Breath.Assert.is_equal "proposal" emitted_proposal proposal
       ])
 
@@ -81,7 +81,7 @@ let case_emitted_sign_proposal =
       Breath.Result.reduce [
         action1
       ; sign_action1
-      ; Breath.Assert.is_equal "proposal id" emitted_proposal_id 1n
+      ; Breath.Assert.is_equal "proposal id" emitted_proposal_id 0x01
       ; Breath.Assert.is_equal "owner" emitted_addr bob.address
       ; Breath.Assert.is_equal "agreement" emitted_agreement true
       ])
@@ -112,7 +112,7 @@ let case_emitted_exe_proposal =
         action1
       ; sign_action1
       ; exe_action1
-      ; Breath.Assert.is_equal "proposal id" emitted_proposal_id 1n
+      ; Breath.Assert.is_equal "proposal id" emitted_proposal_id 0x01
       ; Breath.Assert.is_equal "owner" emitted_addr bob.address
       ])
 

--- a/test/test_emit_events.mligo
+++ b/test/test_emit_events.mligo
@@ -105,8 +105,10 @@ let case_emitted_exe_proposal =
 
       let multisig_address = multisig_contract.originated_address in
       let events = (Util.get_last_events_from multisig_address "resolve_proposal" : (storage_types_proposal_id * address) list) in
+      let poe_events = (Util.get_last_events_from multisig_address "proof_of_event" : (bytes * bytes) list) in
 
       let (emitted_proposal_id, emitted_addr) = Option.unopt (List.head_opt events) in
+      let (emitted_chellenge_id, emitted_payload) = Option.unopt (List.head_opt poe_events) in
 
       Breath.Result.reduce [
         action1
@@ -114,6 +116,8 @@ let case_emitted_exe_proposal =
       ; exe_action1
       ; Breath.Assert.is_equal "proposal id" emitted_proposal_id 0x01
       ; Breath.Assert.is_equal "owner" emitted_addr bob.address
+      ; Breath.Assert.is_equal "proposal id" emitted_chellenge_id 0x01
+      ; Breath.Assert.is_equal "owner" emitted_payload (Bytes.pack param1)
       ])
 
 let case_emitted_receiving_amount =

--- a/test/test_expiration_time.mligo
+++ b/test/test_expiration_time.mligo
@@ -70,7 +70,7 @@ let case_resolve_proposal_passing_expiration_time =
       let exe_action1 = Breath.Context.act_as bob (Helper.resolve_proposal multisig_contract 1n param1) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -112,7 +112,7 @@ let case_resolve_executed_proposal_passing_expiration_time =
       let exe_action2 = Breath.Context.act_as bob (Helper.resolve_proposal multisig_contract 1n param1) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -155,7 +155,7 @@ let case_resolve_rejected_proposal_passing_expiration_time=
       let exe_action2 = Breath.Context.act_as bob (Helper.resolve_proposal multisig_contract 1n param1) in
 
       let storage = Breath.Contract.storage_of multisig_contract in
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1

--- a/test/test_lambda_proposal.mligo
+++ b/test/test_lambda_proposal.mligo
@@ -54,7 +54,7 @@ let case_execute_lambda_proposal =
 
       let add_contract_storage = Breath.Contract.storage_of add_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         action

--- a/test/test_resolve_proposal_entrypoint.mligo
+++ b/test/test_resolve_proposal_entrypoint.mligo
@@ -52,8 +52,8 @@ let case_resolve_proposal =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
-      let proposal2 = Util.unopt (Big_map.find_opt 2n storage.proposals) "proposal 2 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
+      let proposal2 = Util.unopt (Big_map.find_opt 0x02 storage.proposals) "proposal 2 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -238,8 +238,8 @@ let case_execute_transaction_1_of_1 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
-      let proposal2 = Util.unopt (Big_map.find_opt 2n storage.proposals) "proposal 2 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
+      let proposal2 = Util.unopt (Big_map.find_opt 0x02 storage.proposals) "proposal 2 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -299,7 +299,7 @@ let case_execute_transaction_1_of_1_batch =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1
@@ -357,8 +357,8 @@ let case_execute_transaction_3_of_3 =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
-      let proposal2 = Util.unopt (Big_map.find_opt 2n storage.proposals) "proposal 2 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
+      let proposal2 = Util.unopt (Big_map.find_opt 0x02 storage.proposals) "proposal 2 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1

--- a/test/test_sign_only_entrypoint.mligo
+++ b/test/test_sign_only_entrypoint.mligo
@@ -52,8 +52,8 @@ let case_gathering_signatures =
       let balance = Breath.Contract.balance_of multisig_contract in
       let storage = Breath.Contract.storage_of multisig_contract in
 
-      let proposal1 = Util.unopt (Big_map.find_opt 1n storage.proposals) "proposal 1 doesn't exist" in
-      let proposal2 = Util.unopt (Big_map.find_opt 2n storage.proposals) "proposal 2 doesn't exist" in
+      let proposal1 = Util.unopt (Big_map.find_opt 0x01 storage.proposals) "proposal 1 doesn't exist" in
+      let proposal2 = Util.unopt (Big_map.find_opt 0x02 storage.proposals) "proposal 2 doesn't exist" in
 
       Breath.Result.reduce [
         create_action1


### PR DESCRIPTION
to adapt tzip26

- type of proposal_id is change to `bytes`
- `Resolve_proposal` is renamed to `Proof_of_event_challenge`
- emit event `proof_of_event` when resolve a proposal

other
- fix test cases for upgrading the version of ligo compiler

version
- promote version to 0.3 as the changes was incompatible to 0.1